### PR TITLE
Unify auth token storage

### DIFF
--- a/receipt-frontend/src/api/api.js
+++ b/receipt-frontend/src/api/api.js
@@ -7,15 +7,15 @@ const api = axios.create({
 export function setAuthToken(token) {
   if (token) {
     api.defaults.headers.common["Authorization"] = `Bearer ${token}`
-    localStorage.setItem("authToken", token)
+    localStorage.setItem("access", token)
   } else {
     delete api.defaults.headers.common["Authorization"]
-    localStorage.removeItem("authToken")
+    localStorage.removeItem("access")
   }
 }
 
 // On app load, set token from localStorage if present
-const storedToken = localStorage.getItem("authToken")
+const storedToken = localStorage.getItem("access")
 if (storedToken) {
   setAuthToken(storedToken)
 }

--- a/receipt-frontend/src/components/LogoutButton.jsx
+++ b/receipt-frontend/src/components/LogoutButton.jsx
@@ -5,7 +5,7 @@ export default function LogoutButton() {
   const navigate = useNavigate()
 
   function logout() {
-    localStorage.removeItem("authToken")
+    localStorage.removeItem("access")
     api.defaults.headers.common["Authorization"] = null
     navigate("/login")
   }

--- a/receipt-frontend/src/pages/Login.jsx
+++ b/receipt-frontend/src/pages/Login.jsx
@@ -1,5 +1,5 @@
 import { useState } from "react"
-import { useNavigate } from "react-router-dom"
+import { Link, useNavigate } from "react-router-dom"
 import api, { setAuthToken } from "../api/api"
 
 export default function Login() {
@@ -7,8 +7,6 @@ export default function Login() {
   const [username, setUsername] = useState("")
   const [password, setPassword] = useState("")
   const [error, setError] = useState("")
-  localStorage.setItem('access', response.data.access);
-  localStorage.setItem('refresh', response.data.refresh);
 
   async function handleSubmit(e) {
     e.preventDefault()
@@ -65,16 +63,14 @@ export default function Login() {
           Log In
         </button>
       </form>
+      <p className="text-center mt-4">
+        Don't have an account?{' '}
+        <Link to="/register" className="text-blue-600 hover:underline">
+          Register
+        </Link>
+      </p>
     </div>
-    
+
   )
 }
-import { Link } from 'react-router-dom'
-
-<p className="text-center mt-4">
-  Don't have an account?{' '}
-  <Link to="/register" className="text-blue-600 hover:underline">
-    Register
-  </Link>
-</p>
 


### PR DESCRIPTION
## Summary
- store JWT under `access` key only
- adjust login flow and logout button
- clean up `Login` component markup

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686bae9192e0832bb37c9f26b78b9867