### PR TITLE
Use environment variables for settings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+SECRET_KEY=changeme
+DEBUG=True
+ALLOWED_HOSTS=localhost,127.0.0.1
+CORS_ALLOWED_ORIGINS=http://localhost:5173
+POPPLER_PATH=/path/to/poppler/bin
+MEDIA_ROOT=media
+DB_NAME=db.sqlite3

--- a/README.md
+++ b/README.md
@@ -14,7 +14,22 @@ This project is a Django-based web application that uses OCR to extract key data
 - OCR processing libraries
 
 ## Getting Started
-To be added soon.
+1. Install dependencies from `requirements.txt`.
+2. Create a `.env` file in the project root based on `.env.example`.
+3. Run migrations and start the development server.
+
+### Environment Variables
+The application reads configuration from environment variables. The most important ones are:
+
+- `SECRET_KEY` – Django secret key
+- `DEBUG` – set to `True` to enable debug mode
+- `ALLOWED_HOSTS` – comma separated list of allowed hosts
+- `CORS_ALLOWED_ORIGINS` – comma separated list of origins for CORS
+- `POPPLER_PATH` – path to the `poppler` binaries for PDF processing
+- `MEDIA_ROOT` – directory to store uploaded files (optional)
+- `DB_NAME` – SQLite database file location (optional)
+
+See `.env.example` for a full example.
 
 ---
 

--- a/receipt_saver_backend/settings.py
+++ b/receipt_saver_backend/settings.py
@@ -11,21 +11,24 @@ https://docs.djangoproject.com/en/5.2/ref/settings/
 """
 
 from pathlib import Path
+import os
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
+
+POPPLER_PATH = os.getenv('POPPLER_PATH', '')
 
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/5.2/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = 'django-insecure-!j+k#if!#rtu00feg^=4q(no6hk+#u$o7gwca2zm2dxcv*f_!v'
+SECRET_KEY = os.getenv('SECRET_KEY', 'replace-me')
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = os.getenv('DEBUG', 'False').lower() in ('1', 'true', 'yes')
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = os.getenv('ALLOWED_HOSTS', '').split(',') if os.getenv('ALLOWED_HOSTS') else []
 
 
 # Application definition
@@ -81,7 +84,7 @@ WSGI_APPLICATION = 'receipt_saver_backend.wsgi.application'
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': BASE_DIR / 'db.sqlite3',
+        'NAME': os.getenv('DB_NAME', BASE_DIR / 'db.sqlite3'),
     }
 }
 
@@ -128,13 +131,11 @@ STATIC_URL = 'static/'
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
 MEDIA_URL = '/media/'
-MEDIA_ROOT = BASE_DIR / 'media'
+MEDIA_ROOT = os.getenv('MEDIA_ROOT', BASE_DIR / 'media')
 
 REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': [
         'rest_framework.authentication.TokenAuthentication',
     ]
 }
-CORS_ALLOWED_ORIGINS = [
-    "http://localhost:5173",
-]
+CORS_ALLOWED_ORIGINS = os.getenv('CORS_ALLOWED_ORIGINS', 'http://localhost:5173').split(',')

--- a/receipts/ocr.py
+++ b/receipts/ocr.py
@@ -6,12 +6,11 @@ from dateutil import parser
 # OPTIONAL: Set tesseract path manually if needed
 # pytesseract.pytesseract.tesseract_cmd = r'C:\Program Files\Tesseract-OCR\tesseract.exe'
 from pdf2image import convert_from_path
-
-POPPLER_PATH = r"C:\Users\USER\Documents\poppler\poppler-24.08.0\Library\bin"  # Replace this
+from django.conf import settings
 
 def load_images_from_file(path):
     if path.lower().endswith('.pdf'):
-        pages = convert_from_path(path, poppler_path=POPPLER_PATH)
+        pages = convert_from_path(path, poppler_path=settings.POPPLER_PATH or None)
         return pages  # list of PIL Images
     else:
         return [clean_image(path)]  # single image in a list


### PR DESCRIPTION
## Summary
- load sensitive and deployment settings from environment variables
- read poppler path from Django settings
- document configuration variables
- include example `.env`

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'dateutil')*

------
https://chatgpt.com/codex/tasks/task_e_686bae892714832b933bf25247e9daa7